### PR TITLE
update species model to use usda symbols as index key

### DIFF
--- a/data/species.json
+++ b/data/species.json
@@ -244,8 +244,8 @@
     "Notes": {
         "1": "USDA symbols are used as species index key.",
         "2": "When difference between USDA and EPPO codes, scientific_names, or authority occured, USDA information was used.",
-        "3": "Purple nutsedge (CYRO) is used by may also be yellow nutsedge (CYES)."
-        "3": "North Carolina (MD), Texas (TX), Maryland (MD)"
+        "3": "Purple nutsedge (CYRO) is used by may also be yellow nutsedge (CYES).",
+        "4": "North Carolina (MD), Texas (TX), Maryland (MD)"
     },
     "Version": "1.1"
 }


### PR DESCRIPTION
@skovsens just so that you are aware. I went with USDA symbol on Maria's suggestion and because its partly USDA led. But I've also added an `EPPO` key:value pair for easy lookup. 