### PR TITLE
multiprocessing for fetching image metadata in BBoxComponents

### DIFF
--- a/remap_labels.py
+++ b/remap_labels.py
@@ -54,6 +54,7 @@ class RemapLabels:
             self.image_dir,
             self.camera_reference,
             reader,
+            True,
             self.raw_label,
             fullres_image_path=self.fullres_image_path)
         log.info("Fetching image metadata.")


### PR DESCRIPTION
Using multiprocessing for fetching the image metadata in BBoxComponents. This is the most time-consuming part of the process since it needs to read a lot of images. The other parts like mapping and finding intersections don't take much time, and the overhead of the multiprocessing might actually make it slower. We'll have to check this though since the results might be different when we have a large number of images.

Remapping: single process -> 6.5 minutes
Multiprocessing (8 CPUs) -> 2.2 minutes