### PR TITLE
export dem to go along with autosfm changes

### DIFF
--- a/conf/autosfm/autosfm.yaml
+++ b/conf/autosfm/autosfm.yaml
@@ -38,8 +38,6 @@ autosfm_config:
     autosave: True
     export: 
       enabled: True
-      max_height: 20000
-      max_width: 50000
 
   orthomosaic:
     enabled: True


### PR DESCRIPTION
These changes apply for new branch `feature/export-DEM` in AutoSfM repo:

1. setting up config [here](https://github.com/precision-sustainable-ag/autoSfM/blob/3cb5f1362e6cc0dfb2118cecc6a01f0afe5e1759/auto_sfm/config_utils.py#L52-L58)

2. exporting raster DEM [here](https://github.com/precision-sustainable-ag/autoSfM/blob/3cb5f1362e6cc0dfb2118cecc6a01f0afe5e1759/auto_sfm/metashape_utils.py#L277-L287)
